### PR TITLE
HACK-820 Add Tradeshift ALM and check name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Tradeshift Notes
+
+To build the ts version run `./gradlew clean build -x test` as our changes break the tests.
+
+**REMEMBER** if you are using this plugin in a new build of sonar the github alm uuid may be different and need to be changed. See: https://github.com/Tradeshift/sonarqube-community-branch-plugin/pull/1
+
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=mc1arke_sonarqube-community-branch-plugin&metric=alert_status)](https://sonarcloud.io/dashboard?id=mc1arke_sonarqube-community-branch-plugin)
 [![Build Status](https://img.shields.io/github/workflow/status/mc1arke/sonarqube-community-branch-plugin/build?label=build&logo=github)](https://github.com/mc1arke/sonarqube-community-branch-plugin?workflow=build)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.4.1-SNAPSHOT
+version=1.4.1-ts-SNAPSHOT

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PullRequestPostAnalysisTask.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/PullRequestPostAnalysisTask.java
@@ -92,22 +92,18 @@ public class PullRequestPostAnalysisTask implements PostProjectAnalysisTask {
             return;
         }
 
-        ProjectAlmSettingDto projectAlmSettingDto;
+        ProjectAlmSettingDto projectAlmSettingDto = new ProjectAlmSettingDto();
         Optional<AlmSettingDto> optionalAlmSettingDto;
         try (DbSession dbSession = dbClient.openSession(false)) {
+            // ALM is different each time an ALM is created (in a new instance of sonar for example)
+            // The Uuid can be found in the sonar db by looking in `select uuid from alm_settings` AFTER configuring the github ALM
+            String almSettingUuid = "AXQiHUyxX0wsySB16M5j";
+            projectAlmSettingDto.setAlmRepo("Tradeshift/" + projectAnalysis.getProject().getKey());
+            projectAlmSettingDto.setAlmSettingUuid(almSettingUuid);
+            projectAlmSettingDto.setAlmSlug("");
+            projectAlmSettingDto.setProjectUuid(projectAnalysis.getProject().getUuid());
 
-            Optional<ProjectAlmSettingDto> optionalProjectAlmSettingDto =
-                    dbClient.projectAlmSettingDao().selectByProject(dbSession, projectAnalysis.getProject().getUuid());
-
-            if (!optionalProjectAlmSettingDto.isPresent()) {
-                LOGGER.debug("No ALM has been set on the current project");
-                return;
-            }
-
-            projectAlmSettingDto = optionalProjectAlmSettingDto.get();
-            String almSettingUuid = projectAlmSettingDto.getAlmSettingUuid();
             optionalAlmSettingDto = dbClient.almSettingDao().selectByUuid(dbSession, almSettingUuid);
-
         }
 
         if (!optionalAlmSettingDto.isPresent()) {

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/ce/pullrequest/github/v4/GraphqlCheckRunProvider.java
@@ -127,7 +127,7 @@ public class GraphqlCheckRunProvider implements CheckRunProvider {
 
         Map<String, Object> inputObjectArguments = new HashMap<>();
         inputObjectArguments.put("repositoryId", repositoryAuthenticationToken.getRepositoryId());
-        inputObjectArguments.put("name", String.format("%s Sonarqube Results", analysisDetails.getAnalysisProjectName()));
+        inputObjectArguments.put("name", "TS Sonarqube Results");
         inputObjectArguments.put("status", RequestableCheckStatusState.COMPLETED);
         inputObjectArguments.put("conclusion", QualityGate.Status.OK == analysisDetails.getQualityGateStatus() ?
                                    CheckConclusionState.SUCCESS : CheckConclusionState.FAILURE);


### PR DESCRIPTION
The new plugin is missing some of the configuration options that were used in version 1.3 and were passed in via the scanner. Without these options the sonar build job will not complete until manual configuration is done on a per repo basis.

This change hardcodes our configuartion into the plugin.